### PR TITLE
Introduce @@account_api_key class variable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,5 @@ gem "minitest", "~> 5.0"
 gem "standard", "~> 1.3"
 
 gem "httparty"
+
+gem "activesupport", "~> 6.1"

--- a/edusign.gemspec
+++ b/edusign.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "httparty"
+  spec.add_dependency "activesupport"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/edusign/client.rb
+++ b/lib/edusign/client.rb
@@ -5,14 +5,28 @@ module Edusign
     include HTTParty
     base_uri "https://ext.edusign.fr/v1"
 
+    class << self
+      def account_api_key=(key)
+        @@account_api_key = key
+      end
+    end
+
     ALREADY_LOCKED_ERROR_MESSAGE = "Course already locked".freeze
     STUDENT_ALREADY_ADDED_TO_COURSE_ERROR_MESSAGE = "Student already in the list"
     LOCKED_ERROR_MESSAGE = "course locked".freeze
 
+    class NoApiKeyError < StandardError; end
+
     class BadGatewayError < StandardError; end
 
-    def initialize(account_api_key:)
+    def initialize(account_api_key: @@account_api_key)
+      raise NoApiKeyError, "Please provide an Edusing account API key" if account_api_key.nil?
+
       @account_api_key = account_api_key
+    end
+
+    def self.setup
+      yield self
     end
 
     # GROUP

--- a/lib/edusign/client.rb
+++ b/lib/edusign/client.rb
@@ -6,6 +6,10 @@ module Edusign
     base_uri "https://ext.edusign.fr/v1"
 
     class << self
+      def setup
+        yield self
+      end
+
       def account_api_key=(key)
         @@account_api_key = key
       end
@@ -23,10 +27,6 @@ module Edusign
       raise NoApiKeyError, "Please provide an Edusing account API key" if account_api_key.nil?
 
       @account_api_key = account_api_key
-    end
-
-    def self.setup
-      yield self
     end
 
     # GROUP

--- a/lib/edusign/client.rb
+++ b/lib/edusign/client.rb
@@ -1,19 +1,11 @@
+require "active_support/configurable"
 require "httparty"
 
 module Edusign
   class Client
+    include ActiveSupport::Configurable
     include HTTParty
     base_uri "https://ext.edusign.fr/v1"
-
-    class << self
-      def setup
-        yield self
-      end
-
-      def account_api_key=(key)
-        @@account_api_key = key
-      end
-    end
 
     ALREADY_LOCKED_ERROR_MESSAGE = "Course already locked".freeze
     STUDENT_ALREADY_ADDED_TO_COURSE_ERROR_MESSAGE = "Student already in the list"
@@ -23,10 +15,10 @@ module Edusign
 
     class BadGatewayError < StandardError; end
 
-    def initialize(account_api_key: @@account_api_key)
-      raise NoApiKeyError, "Please provide an Edusing account API key" if account_api_key.nil?
-
+    def initialize(account_api_key: config.account_api_key)
       @account_api_key = account_api_key
+
+      raise NoApiKeyError, "Please provide an Edusing account API key" if @account_api_key.nil?
     end
 
     # GROUP


### PR DESCRIPTION
Learn use the same Edusign API key for all the batches. For this reason, the API key was previously set in the [`EdusignService#initialize` method](https://github.com/lewagon/learn/blob/master/app/services/edusign_service.rb#L12-L14).

This PR introduce the `@@account_api_key` class variable and the `account_api_key=(key)` setter which allows to set an API key at the class level. This way, we would be able to set the Edusign API key in an initializer on Learn 👇 

```ruby
# config/initializers/edusign_config.rb

Edusign::Client.setup do |config|
  env = (Rails.env.to_sym == :test) ? :development : Rails.env.to_sym
  # env = :production # NOTE(ssaunier): uncomment when you need to use Edusign production data
  config.account_api_key =  Rails.application.credentials.send(env).dig(:edusign, :api_key)
end
```

Then we can directly instantiate the client without providing the API key each time (by doing `Edusing::Client.new` 👍)