### PR TITLE
Add gateway timeout error

### DIFF
--- a/lib/edusign/client.rb
+++ b/lib/edusign/client.rb
@@ -15,6 +15,7 @@ module Edusign
     class NoApiKeyError < StandardError; end
 
     class BadGatewayError < StandardError; end
+    class GatewayTimeoutError < StandardError; end
 
     def initialize(account_api_key: config.account_api_key)
       @account_api_key = account_api_key
@@ -262,6 +263,7 @@ module Edusign
         self.class.send(http_method, path, body: body, headers: options(opts))
       end
       raise BadGatewayError, request.message if request.code == 502
+      raise GatewayTimeoutError, request.message if request.code == 504
 
       response = Response.new(JSON.parse(request.body, symbolize_names: true))
       raise Response::Error, response.message if response.error?

--- a/lib/edusign/client.rb
+++ b/lib/edusign/client.rb
@@ -15,6 +15,7 @@ module Edusign
     class NoApiKeyError < StandardError; end
 
     class BadGatewayError < StandardError; end
+
     class GatewayTimeoutError < StandardError; end
 
     def initialize(account_api_key: config.account_api_key)

--- a/lib/edusign/client.rb
+++ b/lib/edusign/client.rb
@@ -277,8 +277,8 @@ module Edusign
 
     class Response
       class Error < StandardError
-        PROFESSOR_NOT_FOUND_ERROR_MESSAGE = "Professor not found".freeze
-        PROFESSOR_DELETED_ERROR_MESSAGE = "Professor was deleted".freeze
+        PROFESSOR_NOT_FOUND_ERROR_MESSAGE = "professor not found".freeze
+        PROFESSOR_DELETED_ERROR_MESSAGE = "professor was deleted".freeze
       end
 
       attr_reader :body


### PR DESCRIPTION
Raise a `GatewayTimeoutError` when Edusign answers with a `504` error code.