### PR TITLE
Fix `#find_or_create_professor`

### DIFF
--- a/lib/edusign/client.rb
+++ b/lib/edusign/client.rb
@@ -277,8 +277,8 @@ module Edusign
 
     class Response
       class Error < StandardError
-        PROFESSOR_NOT_FOUND_ERROR_MESSAGE = "Professor not found".freeze
-        PROFESSOR_DELETED_ERROR_MESSAGE = "Professor was deleted".freeze
+        PROFESSOR_NOT_FOUND_ERROR_MESSAGE = "professor not found".freeze
+        PROFESSOR_DELETED_ERROR_MESSAGE = "professor was deleted".freeze
       end
 
       attr_reader :body

--- a/lib/edusign/client.rb
+++ b/lib/edusign/client.rb
@@ -236,7 +236,7 @@ module Edusign
 
       response.result
     rescue Response::Error => e
-      raise e unless [Response::Error::PROFESSOR_NOT_FOUND_ERROR_MESSAGE, Response::Error::PROFESSOR_DELETED_ERROR_MESSAGE].include?(e.message)
+      raise e unless [Response::Error::PROFESSOR_NOT_FOUND_ERROR_MESSAGE, Response::Error::PROFESSOR_DELETED_ERROR_MESSAGE].include?(e.message) || e.message.include?(Response::Error::CANNOT_GET_PROFESSOR_BY_EMAIL_ERROR_MESSAGE)
 
       response = create_professor(first_name: first_name, last_name: last_name, email: email)
       response.result
@@ -286,6 +286,7 @@ module Edusign
       class Error < StandardError
         PROFESSOR_NOT_FOUND_ERROR_MESSAGE = "professor not found".freeze
         PROFESSOR_DELETED_ERROR_MESSAGE = "professor was deleted".freeze
+        CANNOT_GET_PROFESSOR_BY_EMAIL_ERROR_MESSAGE = "Error - cannot get professor by email".freeze
       end
 
       attr_reader :body


### PR DESCRIPTION
Edusign API now returns the following error when we try to find a professor who doesn't exist by email 👇 

```
Error - cannot get professor by email guillaume.alleon@gmail.com
```

I referenced this error in a new constant in `Response::Error::CANNOT_GET_PROFESSOR_BY_EMAIL_ERROR_MESSAGE` and stoped rising an error when the API return this message.