### PR TITLE
Add Endpoints

### DIFF
--- a/lib/edusign/client.rb
+++ b/lib/edusign/client.rb
@@ -144,6 +144,10 @@ module Edusign
       raise e unless e.message == STUDENT_ALREADY_ADDED_TO_COURSE_ERROR_MESSAGE
     end
 
+    def remove_student_from_course(course_uid:, student_uid:)
+      api :delete, "/course/attendance/#{course_uid}", {studentId: student_uid}.to_json
+    end
+
     def send_signature_email(course_uid:)
       students = course(course_uid: course_uid)[:STUDENTS].reject { |student| student[:state] }.map { |student| student[:studentId] }
       api :post, "/course/send-sign-emails", {"course" => course_uid, "students" => students}.to_json

--- a/lib/edusign/client.rb
+++ b/lib/edusign/client.rb
@@ -126,9 +126,14 @@ module Edusign
       api :delete, "/course/#{course_uid}"
     end
 
-    def courses(group_uid: nil)
+    def courses(group_uid: nil, starts_at: nil, ends_at: nil)
+      query = {
+        groupId: group_uid,
+        start: starts_at,
+        end: ends_at
+      }.compact
       path = "/course"
-      path += "?groupId=#{group_uid}" if group_uid.present?
+      path += "?#{query.to_query}" if query.present?
       response = api :get, path
       response.result
     end

--- a/lib/edusign/version.rb
+++ b/lib/edusign/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Edusign
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
This is a first step to process the request in https://github.com/lewagon/help/issues/3569 to remove a student from sheets he already signed w/o altering the previous ones 👌 

I had an answer from one of Edusign's cofounder who suggested: 


> Une solution est donc de :
> - Get all courses - Avec en paramètre une date de début et de fin et le groupe id (du 30 août au 4 septembre par exemple)
> - Remove student from the attendance list - Sur chaque id de feuille récupérée juste avant, enlever le student (Grégory) du cours

> Il n'est alors pas nécessaire (mais possible) de supprimer l'apprenant du groupe. Ce qui permet, si besoin, d'avoir une trace du passage de l'apprenant dans le groupe.

Here are the two corresponding endpoints documented on Postman 👇 
- https://www.postman.com/edusignteam/workspace/edusign-public/example/25471755-996c4ff3-4b73-4d48-b12a-4089bbb40707
- https://www.postman.com/edusignteam/workspace/edusign-public/example/25471755-2e4a1d3f-3a63-44cd-b7c6-e50f717dab66
