### PR TITLE
Fix #create_or_update_student

### DIFF
--- a/lib/edusign/client.rb
+++ b/lib/edusign/client.rb
@@ -174,7 +174,8 @@ module Edusign
     end
 
     def create_or_update_student(first_name:, last_name:, email:, student_uid: nil, group_uids: [])
-      student = student_uid.present? ? student_by_uid(student_uid: student_uid) : student_by_email(email: email)
+      student = student_by_uid(student_uid: student_uid)
+      student = student_by_email(email: email) if student.nil?
       raise Response::Error, "Student doesn't exist" if student.nil?
       raise Response::Error, "Student was deleted from edusign" if student[:HIDDEN] == 1
 

--- a/lib/edusign/client.rb
+++ b/lib/edusign/client.rb
@@ -174,12 +174,12 @@ module Edusign
     end
 
     def create_or_update_student(first_name:, last_name:, email:, student_uid: nil, group_uids: [])
-      student = student_by_uid(student_uid: student_uid)
-      student = student_by_email(email: email) if student.nil?
+      @student = student_by_uid(student_uid: student_uid) if student_uid.present?
+      @student = student_by_email(email: email) if @student.nil?
       raise Response::Error, "Student doesn't exist" if student.nil?
-      raise Response::Error, "Student was deleted from edusign" if student[:HIDDEN] == 1
+      raise Response::Error, "Student was deleted from edusign" if @student[:HIDDEN] == 1
 
-      update_student(student_uid: student[:ID], first_name: first_name, last_name: last_name, email: email, group_uids: group_uids)
+      update_student(student_uid: @student[:ID], first_name: first_name, last_name: last_name, email: email, group_uids: group_uids)
     rescue Response::Error => _e
       create_student(first_name: first_name, last_name: last_name, email: email, group_uids: group_uids)
     end


### PR DESCRIPTION
Received the following response from Edusign CTO about my question related to student duplicates:

<img width="978" alt="Screenshot 2024-01-25 at 11 02 19" src="https://github.com/lewagon/edusign/assets/25386941/01f874b6-b9bc-45a1-8936-a997fabcee77">

After investigations, I think we should always try to find a student with they uid and with they email if not found with the uid. WDYT?