### PR TITLE
Updated API documentation + Postman link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Edusign Ruby Client for RESTful API
 
 ## Documentation
-- Official docs https://ext.edusign.fr/doc/
-- Postman Collection [EDUSIGN API](https://www.postman.com/edusignteam/workspace/edusign-public/collection/25471755-efa72d54-fe36-4e1a-80d9-65b7c928d47a)
+- Official docs https://developers.edusign.com/
+- Postman Collection [EDUSIGN API](https://www.postman.com/edusignteam/workspace/public/collection/25471755-efa72d54-fe36-4e1a-80d9-65b7c928d47a)


### PR DESCRIPTION
Changed the link to the Postman collection (was HS) + changed the link of the API documentation to the new one on ReadMe (more complete & more powerful)